### PR TITLE
Avoid continuous api call when jobName is undefined

### DIFF
--- a/src/frontend/public/javascripts/flowqueuesControllers.js
+++ b/src/frontend/public/javascripts/flowqueuesControllers.js
@@ -14,17 +14,19 @@ angular.module("flowqueuesControllers", [])
   var refresh = function() {
     var start = new Date();
     $scope.job = $routeParams.jobName
-    request = $http.get("./api/jobs/" + $routeParams.jobName + "/tasks");
-    request.success(function(data) {
-      $scope.tasks = data;
-      var end = new Date();
-      $scope.last_updated = end;
-      setTimeout(refresh, Math.max((end - start) * 10, 200));
-    });
-    request.error(function(err) {
-      var end = new Date();
-      setTimeout(refresh, 2000);
-    });  
+    if($routeParams.jobName){
+      request = $http.get("./api/jobs/" + $routeParams.jobName + "/tasks");
+      request.success(function(data) {
+        $scope.tasks = data;
+        var end = new Date();
+        $scope.last_updated = end;
+        setTimeout(refresh, Math.max((end - start) * 10, 200));
+      });
+      request.error(function(err) {
+        var end = new Date();
+        setTimeout(refresh, 2000);
+      });
+    }
   };
   refresh();
 }])


### PR DESCRIPTION
Fix multiple 404 errors when JobDetailCtrl controller is called when going back to homepage, but jobName is undefined.
